### PR TITLE
[WIP] Incorporate Metadata into Table Parser

### DIFF
--- a/capalyzer/packet_builder/sub_factories/pathway_factory.py
+++ b/capalyzer/packet_builder/sub_factories/pathway_factory.py
@@ -11,7 +11,7 @@ class PathwayFactory(SubFactory):
             """Return True if a key is not blacklisted."""
             out = True
             for black in [] if show_unmapped else ['UNMAPPED', 'UNINTEGRATED']:
-                out &= black in key
+                out &= black not in key
             return out
 
         result = 'path_cov' if coverage else 'relab_path_abunds'

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -35,6 +35,10 @@ class DataTableFactory:
     def __init__(self, packet_dir):
         self.packet_dir = packet_dir
 
+    def set_metadata(self, metadata_tbl):
+        """Set the internal metadata table which will be used to filter samples in tables."""
+        pass
+
     def csv_in_dir(self, fname, **kwargs):
         tbl = pd.read_csv(
             join(self.packet_dir, fname),

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -53,7 +53,7 @@ class DataTableFactory:
             tbl = tbl.fillna(kwargs['fillna'])
         if kwargs.get('normalize', False):
             tbl = (tbl.T / tbl.T.sum()).T
-        if self.metadata and kwargs.get('metadata_filter', True):
+        if self.metadata is not None and kwargs.get('metadata_filter', True):
             tbl = tbl.loc[self.metadata.index]
         return tbl
 
@@ -102,7 +102,9 @@ class DataTableFactory:
     def hmp(self, **kwargs):
         """Return a table of HMP distances."""
         tbl = self.csv_in_dir(HMP_COMPARISON, metadata_filter=False, **kwargs)
-        return tbl.loc[tbl['sample_name'] in self.metadata.index]
+        if self.metadata is not None:
+            tbl = tbl.loc[tbl['sample_name'] in self.metadata.index]
+        return tbl
 
     def macrobes(self, **kwargs):
         """Return a table of macrobe abundances."""

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -36,7 +36,7 @@ class DataTableFactory:
     def __init__(self, packet_dir, metadata_tbl=None):
         self.packet_dir = packet_dir
         self.metadata = None
-        if metadata_tbl:
+        if metadata_tbl is not None:
             self.set_metadata(metadata_tbl)
 
     def set_metadata(self, metadata_tbl):

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -103,7 +103,7 @@ class DataTableFactory:
         """Return a table of HMP distances."""
         tbl = self.csv_in_dir(HMP_COMPARISON, metadata_filter=False, **kwargs)
         if self.metadata is not None:
-            tbl = tbl.loc[tbl['sample_name'] in self.metadata.index]
+            tbl = tbl.loc[tbl['sample_name'].isin(self.metadata.index)]
         return tbl
 
     def macrobes(self, **kwargs):

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -33,12 +33,15 @@ from ..constants import (
 
 class DataTableFactory:
 
-    def __init__(self, packet_dir):
+    def __init__(self, packet_dir, metadata_tbl=None):
         self.packet_dir = packet_dir
+        self.metadata = None
+        if metadata_tbl:
+            self.set_metadata(metadata_tbl)
 
     def set_metadata(self, metadata_tbl):
         """Set the internal metadata table which will be used to filter samples in tables."""
-        pass
+        self.metadata = metadata_tbl
 
     def csv_in_dir(self, fname, **kwargs):
         tbl = pd.read_csv(
@@ -50,6 +53,8 @@ class DataTableFactory:
             tbl = tbl.fillna(kwargs['fillna'])
         if kwargs.get('normalize', False):
             tbl = (tbl.T / tbl.T.sum()).T
+        if self.metadata and kwargs.get('metadata_filter', True):
+            tbl = tbl.loc[self.metadata.index]
         return tbl
 
     def taxonomy(self, **kwargs):
@@ -96,7 +101,8 @@ class DataTableFactory:
 
     def hmp(self, **kwargs):
         """Return a table of HMP distances."""
-        return self.csv_in_dir(HMP_COMPARISON, **kwargs)
+        tbl = self.csv_in_dir(HMP_COMPARISON, metadata_filter=False, **kwargs)
+        return tbl.loc[tbl['sample_name'] in self.metadata.index]
 
     def macrobes(self, **kwargs):
         """Return a table of macrobe abundances."""

--- a/capalyzer/packet_parser/dataframes.py
+++ b/capalyzer/packet_parser/dataframes.py
@@ -5,8 +5,9 @@ from scipy.spatial.distance import pdist, squareform
 from .diversity_metrics import (
     shannon_entropy,
     richness,
+    chao1,
     jensen_shannon_dist,
-    rho_proportionality
+    rho_proportionality,
 )
 from ..constants import (
     CARD_RPKM,
@@ -113,10 +114,13 @@ class DataTableFactory:
     def alpha_diversity(self, tbl, **kwargs):
         """Return generic alpha diversity table."""
         metric = kwargs.get('metric', 'shannon_entropy').lower()
+        rarefy = kwargs.get('rarefy', 0)
         if metric == 'shannon_entropy':
-            return tbl.apply(shannon_entropy)
+            return tbl.apply(shannon_entropy, rarefy=rarefy)
         elif metric == 'richness':
-            return tbl.apply(richness)
+            return tbl.apply(richness, rarefy=rarefy)
+        elif metric == 'chao1':
+            return tbl.apply(chao1, rarefy=rarefy)
 
     def taxa_beta_diversity(self, **kwargs):
         """Return a distance matrix between taxa."""

--- a/capalyzer/packet_parser/diversity_metrics.py
+++ b/capalyzer/packet_parser/diversity_metrics.py
@@ -40,7 +40,7 @@ def richness(row, rarefy=0):
 
 def chao1(row, rarefy=0):
     """Return richnes of an iterable"""
-    row_sum, R, S, D = sum(row), 0, 0, 0
+    row_sum, R, S, D = sum(row), 0, 0, 0.0000001
     num_reads = MIL if math.isclose(row_sum, 1) else row_sum  # default to 1M reads if compositional
     num_reads = rarefy if rarefy > 0 else num_reads  # if rarefy is set use that as read count
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 setuptools
 setuptools.setup(
     name='capalyzer',
-    version='2.1.0',
+    version='2.2.0',
     description="Parsing functionality for the metasub CAP",
     author="David C. Danko",
     author_email='dcdanko@gmail.com',

--- a/tests/test_packet_parser.py
+++ b/tests/test_packet_parser.py
@@ -70,7 +70,7 @@ class TestPacketParser(TestCase):
         metadata = pd.DataFrame({'foo': {'haib18CEM5332_HMGTJCCXY_SL342402': 1}})
         table_factory = DataTableFactory(PACKET_DIR, metadata_tbl=metadata)
         tbl = table_factory.macrobes()
-        self.assertEqual(tbl.shape(), (1, 38))
+        self.assertEqual(tbl.shape, (1, 38))
 
     def test_metadata_filter_hmp(self):
         """Test that a basic table is metadata filtered."""

--- a/tests/test_packet_parser.py
+++ b/tests/test_packet_parser.py
@@ -81,4 +81,4 @@ class TestPacketParser(TestCase):
         table_factory.set_metadata(metadata)
         hmp2 = table_factory.hmp()
 
-        self.assertEqual(hmp1.shape[0], hmp2.shape[0] // 2)
+        self.assertEqual(hmp1.shape[0] // 2, hmp2.shape[0])

--- a/tests/test_packet_parser.py
+++ b/tests/test_packet_parser.py
@@ -54,6 +54,11 @@ class TestPacketParser(TestCase):
         table_factory = DataTableFactory(PACKET_DIR)
         table_factory.taxa_alpha_diversity()
 
+    def test_taxa_chao1(self):
+        """Test we can make alpha div vec."""
+        table_factory = DataTableFactory(PACKET_DIR)
+        table_factory.taxa_alpha_diversity(metric='chao1', rarefy=1000)
+
     def test_taxa_beta_div(self):
         """Test we can make beta div table."""
         basic_test_runner(self, 'taxa_beta_diversity')

--- a/tests/test_packet_parser.py
+++ b/tests/test_packet_parser.py
@@ -1,5 +1,7 @@
 """Test suite for packet building."""
 
+import pandas as pd
+
 from unittest import TestCase
 from os.path import join, dirname
 
@@ -62,3 +64,21 @@ class TestPacketParser(TestCase):
     def test_taxa_beta_div(self):
         """Test we can make beta div table."""
         basic_test_runner(self, 'taxa_beta_diversity')
+
+    def test_metadata_filter_general(self):
+        """Test that a basic table is metadata filtered."""
+        metadata = pd.DataFrame({'foo': {'haib18CEM5332_HMGTJCCXY_SL342402': 1}})
+        table_factory = DataTableFactory(PACKET_DIR, metadata_tbl=metadata)
+        tbl = table_factory.macrobes()
+        self.assertEqual(tbl.shape(), (1, 38))
+
+    def test_metadata_filter_hmp(self):
+        """Test that a basic table is metadata filtered."""
+        table_factory = DataTableFactory(PACKET_DIR)
+        hmp1 = table_factory.hmp()
+
+        metadata = pd.DataFrame({'foo': {'haib18CEM5332_HMGTJCCXY_SL342402': 1}})
+        table_factory.set_metadata(metadata)
+        hmp2 = table_factory.hmp()
+
+        self.assertEqual(hmp1.shape[0], hmp2.shape[0] // 2)


### PR DESCRIPTION
Add feature to set a metadata table for a parser. Make sure that every table produced by the parser produces only and all of the samples from the metadata table in the same order as the metadata table.

Add a couple other bonus features too
- [x] Chao1 Richness
- [x] Rarefy taxa vectors before producing diversity metric
- [ \x] fix pathways parsing


 